### PR TITLE
Fix Deployed URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "preview-${{ github.ref_name }}"
-      url: ${{ steps.build-publish.outputs.page_url }}
+      url: "${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.page_url }}"
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4
@@ -45,7 +45,7 @@ jobs:
             
             # Replace slashes with dashes for safety
             DEPLOY_PATH="${BRANCH_NAME//\//-}"
-            echo "deploy_path=${DEPLOY_PATH}" >> $GITHUB_ENV
+            echo "deploy_path=${DEPLOY_PATH}" >> $GITHUB_OUTPUT
             
             # Create preview directory structure
             mkdir -p "$BUILD_PATH/${DEPLOY_PATH}"
@@ -66,6 +66,6 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `🎉 **Preview Deployed!**
-                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ env.deploy_path }}" target="_blank">View Preview</a>`
+                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.page_url }}" target="_blank">View Preview</a>`
               });
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
 
-# Add concurrency settings
 # tack on branch name to allow for cross-branch concurrency
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,33 +20,41 @@ permissions:
   pull-requests: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_path: ${{ steps.set-vars.outputs.deploy_path }}
+    steps:
+      - id: set-vars
+        shell: bash
+        run: |
+          # Replace slashes with dashes in branch name
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BRANCH_NAME="${{ github.head_ref }}"
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+          fi
+          
+          # Replace slashes with dashes for safety
+          DEPLOY_PATH="${BRANCH_NAME//\//-}"
+          echo "deploy_path=$DEPLOY_PATH" >> $GITHUB_OUTPUT
+
   build-and-deploy:
     runs-on: ubuntu-latest
+    needs: setup
     environment:
-      name: "preview-${{ github.ref_name }}"
-      url: "${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}"
-    outputs:
-      deploy_path: ${{ steps.build-publish.outputs.deploy_path }}
+      name: "preview-${{ needs.setup.outputs.deploy_path }}"
+      url: "${{ steps.build-publish.outputs.page_url }}/${{ needs.setup.outputs.deploy_path }}"
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4
+        env:
+          BUILD_PATH: preview-out # change to your build folder
+          DEPLOY_PATH: ${{ needs.setup.outputs.deploy_path }}
         with:
-          path: preview-out # change to your build folder
+          path: ${{ env.BUILD_PATH }} 
           build_command: |
             npm run build
-
-            BUILD_PATH=preview-out
-
-            # Replace slashes with dashes in branch name
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              BRANCH_NAME="${{ github.head_ref }}"
-            else
-              BRANCH_NAME="${{ github.ref_name }}"
-            fi
-            
-            # Replace slashes with dashes for safety
-            DEPLOY_PATH="${BRANCH_NAME//\//-}"
-            echo "deploy_path=${DEPLOY_PATH}" >> $GITHUB_OUTPUT
             
             # Create preview directory structure
             mkdir -p "$BUILD_PATH/${DEPLOY_PATH}"
@@ -56,9 +63,8 @@ jobs:
             # Copy 404.html to root for routing
             cp dist/404.html $BUILD_PATH/
 
-
       - name: Comment on PR
-        if: success() && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -68,6 +74,6 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `🎉 **Preview Deployed!**
-                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}" target="_blank">View Preview</a>`
+                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ needs.setup.outputs.deploy_path }}" target="_blank">View Preview</a>`
               });
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
     environment:
       name: "preview-${{ github.ref_name }}"
       url: "${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}"
+    outputs:
+      deploy_path: ${{ steps.build-publish.outputs.deploy_path }}
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
     needs: setup
     environment:
       name: "preview-${{ needs.setup.outputs.deploy_path }}"
-      url: "${{ steps.build-publish.outputs.page_url }}/${{ needs.setup.outputs.deploy_path }}"
+      url: "${{ steps.build-publish.outputs.page_url }}${{ needs.setup.outputs.deploy_path }}"
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,6 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `🎉 **Preview Deployed!**
-                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ needs.setup.outputs.deploy_path }}" target="_blank">View Preview</a>`
+                👉 <a href="${{ steps.build-publish.outputs.page_url }}${{ needs.setup.outputs.deploy_path }}" target="_blank">View Preview</a>`
               });
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "preview-${{ github.ref_name }}"
-      url: "${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.page_url }}"
+      url: "${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}"
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4
@@ -66,6 +66,6 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `🎉 **Preview Deployed!**
-                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.page_url }}" target="_blank">View Preview</a>`
+                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}" target="_blank">View Preview</a>`
               });
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,15 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ['*']
+
   pull_request:
-    branches: ['main']
+    branches:
+      - main
 
 # Add concurrency settings
+# tack on branch name to allow for cross-branch concurrency
 concurrency: 
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -22,8 +24,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     environment:
-      name: 'preview-${{ github.ref_name }}'
-      url: '${{ steps.build-publish.outputs.page_url }}'
+      name: "preview-${{ github.ref_name }}"
+      url: ${{ steps.build-publish.outputs.page_url }}
     steps:
       - id: build-publish
         uses: bitovi/github-actions-react-to-github-pages@v1.2.4
@@ -32,30 +34,29 @@ jobs:
           build_command: |
             npm run build
 
+            BUILD_PATH=preview-out
+
             # Replace slashes with dashes in branch name
             if [ "${{ github.event_name }}" == "pull_request" ]; then
               BRANCH_NAME="${{ github.head_ref }}"
             else
-              BRANCH_NAME="${GITHUB_REF_NAME}"
+              BRANCH_NAME="${{ github.ref_name }}"
             fi
             
             # Replace slashes with dashes for safety
             DEPLOY_PATH="${BRANCH_NAME//\//-}"
-            echo "deploy_path=${DEPLOY_PATH}" >> $GITHUB_OUTPUT
+            echo "deploy_path=${DEPLOY_PATH}" >> $GITHUB_ENV
             
             # Create preview directory structure
-            mkdir -p "preview-out/${DEPLOY_PATH}"
-            cp -r dist/* "preview-out/${DEPLOY_PATH}/"
+            mkdir -p "$BUILD_PATH/${DEPLOY_PATH}"
+            cp -r dist/* "$BUILD_PATH/${DEPLOY_PATH}/"
             
             # Copy 404.html to root for routing
-            cp dist/404.html preview-out/
+            cp dist/404.html $BUILD_PATH/
 
 
       - name: Comment on PR
-        # if: |
-        #   github.event_name == 'pull_request' && 
-        #   steps.deploy.conclusion == 'success' && 
-        #   steps.wait-for-pages.conclusion == 'success'
+        if: success() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -65,6 +66,6 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `🎉 **Preview Deployed!**
-                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ steps.build-publish.outputs.deploy_path }}" target="_blank">View Preview</a>`
+                👉 <a href="${{ steps.build-publish.outputs.page_url }}/${{ env.deploy_path }}" target="_blank">View Preview</a>`
               });
             }


### PR DESCRIPTION
Cleanup and proper setting of output values.

We were missing that the script command is passed to the action and is not actually running in the workflow. So, I created a new job to set the vars properly. 🤓 

Note that the push to the branch with a PR open generates two Actions runs: one for the branch, and one for the PR. There's no simple way to avoid this. I built something for Moody's to mitigate this, that should think about re-writing for Bitovi and publishing.